### PR TITLE
updated readme.md with correct pip command name

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ This is a plugin that enables you to use your assumed role credentials to open t
 ## Installation
 
 ```
-pip install awsume-console-plugin
+pip3 install awsume-console-plugin
 ```
 
 If you've installed awsume with `pipx`, this will install the console plugin in awsume's virtual environment:


### PR DESCRIPTION
Many installations have gotten rid of the `pip` command due to contention between Python 2 and Python 3. The better way to invoke the Python 3 version of PIP is to use the `pip3` command.